### PR TITLE
Removing bearertoken auth and adding some docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,41 @@ This repository contains:
 ### Installation
 
 1. Clone this repo to your Databricks workspace. We recommend making it read-only to all users.
-2. (Optionally) Spin up sample observability infrastructure on your Databricks workspace using bootstrap scripts in obs-infra/.
-3. Install the collector by specifying a cluster init script and setting two environment variables to point to your observability endpoint.
+2. (Optionally) Spin up sample observability infrastructure on your Databricks workspace using bootstrap scripts in setup/.
+3. Install the collector by specifying a cluster init script and setting any environment variables required by the init script
+    - If testing against the sample infrastructure, use the script [sample_init.sh](agent/sample_init.sh) and set both `DB_API_TOKEN` and `OTLP_HTTP_ENDPOINT`
+    - If deploying against an OTLP collector that's not hosted on a Databricks cluster, use [init.sh](agent/init.sh) and set `OTLP_HTTP_ENDPOINT`
+
+### Debugging
+
+#### Debugging the Cluster Collector
+
+If you aren't seeing any metrics flowing through to your target observability system you should start your debugging journey by verifying that the OTEL collector running on your cluster is running smoothly.
+
+1. Check the status of the Open Telemetry collector service.  In a notebook run this cell:
+
+``` 
+%sh
+
+systemctl status databricks-otelcol.service
+```
+
+You should expect to see the `Active` field set to `active (running)`.  Whether the service is up or down, you're not getting
+metrics so you should still proceed to the next step and analyze the service logs to gather more signal.
+
+2. Check the collector service's logs.  In a notebook run this cell:
+
+```
+%sh
+
+journalctl -u databricks-otelcol.service
+```
+
+The collector's logs are pretty good and will tell you if there were any issues exporting metrics such as network reachability
+or issues with your configuration.  
+
+If all is going well from the collector's perspective you'll see a bunch of friendly looking INFO messages stating that metrics
+are being exported.  If this is the case the problem is likely upstream in the target collector.
 
 ### Limitations
 - Does not work with serverless compute

--- a/agent/sample_init.sh
+++ b/agent/sample_init.sh
@@ -14,6 +14,11 @@ initialize_env() {
 generate_config() {
 	local config_path="/databricks/otelcol/config.yaml"
 	cat <<EOF | envsubst >$config_path
+extensions:
+  bearertokenauth:
+    scheme: "Bearer"
+    token: "\${DB_API_TOKEN}"
+
 receivers:
   hostmetrics:
     collection_interval: 10s
@@ -46,6 +51,8 @@ receivers:
 exporters:
   otlphttp:
     endpoint: "\${OTLP_HTTP_ENDPOINT}"
+    auth:
+      authenticator: bearertokenauth
   debug:
 
 processors:
@@ -62,6 +69,7 @@ processors:
         action: insert
 
 service:
+  extensions: [bearertokenauth]
   pipelines:
     metrics:
       receivers: [hostmetrics, prometheus]


### PR DESCRIPTION
When deploying this against a non-demo opentelemetry collector (i.e. one that's not hosted on a Databricks cluster) the bearertokenauth blocks cause issues.  If you don't specify a Databricks API Token env var the collector doesn't start.  We could just have users set a fake API Token but that's not good UX.  I propose that we don't include bearertoken auth in the primary init script and create a new init script specifically for working against the sample infrastructure.